### PR TITLE
[Help Needed] Become The Zone. easier way to edit boxed zones.

### DIFF
--- a/addons/sourcemod/scripting/fuckZones.sp
+++ b/addons/sourcemod/scripting/fuckZones.sp
@@ -667,7 +667,6 @@ public Action OnPlayerRunCmd(int client, int& buttons, int& impulse, float vel[3
 			if (buttons & IN_BACK)
 				fSpeed *= -1.0;
 
-			PrintToChatAll("%.2f", fSpeed);
 			float fEyeAngles[3], fFwdAngles[3];
 			GetClientEyeAngles(client, fEyeAngles);
 			GetAngleVectors(fEyeAngles, fFwdAngles, NULL_VECTOR, NULL_VECTOR);

--- a/addons/sourcemod/scripting/fuckZones.sp
+++ b/addons/sourcemod/scripting/fuckZones.sp
@@ -652,7 +652,7 @@ public Action OnPlayerRunCmd(int client, int& buttons, int& impulse, float vel[3
 			g_iBecameZone[client] = 0;
 			SetEntityMoveType(client, MOVETYPE_WALK);
 			SetEntProp(client, Prop_Data, "m_takedamage", 2);
-			TeleportEntity(client, g_fOldOrigin[client]);
+			TeleportEntity(client, g_fOldOrigin[client], NULL_VECTOR, NULL_VECTOR);
 		}
 		else if ((buttons & IN_FORWARD || buttons & IN_BACK) && g_fNextMoveZone[client] <= GetGameTime() && !(buttons & IN_RELOAD))
 		{


### PR DESCRIPTION
It works by teleporting you inside the zone. You look at a face ( right now it's purely angles so it's not very accurate, but that's beyond my skills ) and move forward or backward to make the face shorter or longer. CTRL / Shift / CTRL + SHIFT reduce the speed at which the face moves towards you for accurate changing. Holding Reload allows you to noclip and holding Use will stop you from being teleported to the middle when you edit something.

The thing missing is giving support for getting outside the zone to edit, because it's only by angles it's not working properly when you get outside the zone.
Also please test it because it's a big change and although I tested I cannot be sure no bugs are there.